### PR TITLE
Change CSP rules to fix browser platform warnings.

### DIFF
--- a/App/www/index.html
+++ b/App/www/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
         <meta http-equiv="Content-Security-Policy" 
-             content="default-src * gap://ready file:; style-src 'self' 'unsafe-inline'; img-src 'self'; script-src 'self'">
+             content="default-src * gap://ready file: data:; style-src 'self' 'unsafe-inline'; img-src 'self'; script-src 'self'">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
         <meta name="theme-color" content="#2196f3">


### PR DESCRIPTION
Hi,

Related to issue #18;

Added `'unsafe-inline'` to `image-src`, and `data:` to `default-src` CSP values to fix browser warnings.

The other changes were from my IDE removing extra white-spaces. Let me know if I should remove them to make reviewing easier :+1: 

It may work fine on Android emulator, but at least for the browser platform it appears to raise some warnings in my browser console.

![image](https://user-images.githubusercontent.com/304786/88999617-22e92700-d349-11ea-9c28-fe20ea5f939a.png)

After the change:

![image](https://user-images.githubusercontent.com/304786/88999625-27addb00-d349-11ea-8b96-2e30126c9a18.png)
