### PR TITLE
Ignore Yarn lock file too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_store
 /App/google-services.json
 /App/package-lock.json
+/App/yarn.lock
 /App/package.json
 /App/www/js/push.js
 /App/plugins/*
@@ -9,6 +10,7 @@
 /App/node_modules/*
 /Android26/google-services.json
 /Android26/package-lock.json
+/Android26/yarn.lock
 /Android26/package.json
 /Android26/www/js/push.js
 /Android26/plugins/*


### PR DESCRIPTION
We have the NPM lock file ignored, maybe ignore the Yarn lock too?

Related to #18 